### PR TITLE
Use PerScopeLifetime rather than PerRequestLifeTime with LightInject

### DIFF
--- a/DependencyInjection/Adapters/LightInjectAdapter.cs
+++ b/DependencyInjection/Adapters/LightInjectAdapter.cs
@@ -22,7 +22,7 @@ namespace FeatureTests.On.DependencyInjection.Adapters {
         }
 
         public override void RegisterPerWebRequest(Type serviceType, Type implementationType) {
-            container.Register(serviceType, implementationType, new PerRequestLifeTime());
+            container.Register(serviceType, implementationType, new PerScopeLifetime());
         }
 
         public override void RegisterInstance(Type serviceType, object instance) {


### PR DESCRIPTION
Quote: "The PerRequestLifetime gives you a new instance per request where request represents calling GetInstance on the container. The lifetime you are looking for is the PerScopeLifetime where one instance is produced for each scope. The Scope starts when the web request starts and ends when the web request ends." https://github.com/seesharper/LightInject/issues/131
