### PR TITLE
Updated special case messages for Simple Injector.

### DIFF
--- a/DependencyInjection/7_PropertyTests.cs
+++ b/DependencyInjection/7_PropertyTests.cs
@@ -16,11 +16,11 @@ namespace FeatureTests.On.DependencyInjection
         I have not yet decided whether this table is worth keeping, so do not assign much weight to these tests.     
     ")]
     [FeatureScoring(FeatureScoring.NotScored)]
-    [SpecialCase(typeof(SimpleInjectorAdapter), @"
-        Simple Injector does not inject properties out of the box, but this behavior 
-        can be changed by replacing the `Container.Options.PropertySelectionBehavior`.
-        For more info see: https://bit.ly/14soDfe.
-    ", Skip = true)]
+    [SpecialCase(typeof(SimpleInjectorAdapter),
+        "Simple Injector does not inject properties out of the box, but this behavior can be changed by " +
+        "replacing the Container.Options.PropertySelectionBehavior. For more info see: " +
+        "https://simpleinjector.org/noprop.",
+        Skip = true)]
     public class PropertyTests {
         [Feature]
         [DisplayName("Simple dependency")]

--- a/DependencyInjection/7_PropertyTests.cs
+++ b/DependencyInjection/7_PropertyTests.cs
@@ -17,7 +17,7 @@ namespace FeatureTests.On.DependencyInjection
     ")]
     [FeatureScoring(FeatureScoring.NotScored)]
     [SpecialCase(typeof(SimpleInjectorAdapter), @"
-        Simple Injector does not inject properties out of the box, but this behavior
+        Simple Injector does not inject properties out of the box, but this behavior 
         can be changed by replacing the Container.Options.PropertySelectionBehavior. 
         For more info see: https://simpleinjector.org/noprop.
     ", Skip = true)]

--- a/DependencyInjection/7_PropertyTests.cs
+++ b/DependencyInjection/7_PropertyTests.cs
@@ -16,11 +16,11 @@ namespace FeatureTests.On.DependencyInjection
         I have not yet decided whether this table is worth keeping, so do not assign much weight to these tests.     
     ")]
     [FeatureScoring(FeatureScoring.NotScored)]
-    [SpecialCase(typeof(SimpleInjectorAdapter),
-        "Simple Injector does not inject properties out of the box, but this behavior can be changed by " +
-        "replacing the Container.Options.PropertySelectionBehavior. For more info see: " +
-        "https://simpleinjector.org/noprop.",
-        Skip = true)]
+    [SpecialCase(typeof(SimpleInjectorAdapter), @"
+        Simple Injector does not inject properties out of the box, but this behavior can be changed by 
+        replacing the Container.Options.PropertySelectionBehavior. For more info see: 
+        https://simpleinjector.org/noprop.
+    ", Skip = true)]
     public class PropertyTests {
         [Feature]
         [DisplayName("Simple dependency")]

--- a/DependencyInjection/7_PropertyTests.cs
+++ b/DependencyInjection/7_PropertyTests.cs
@@ -17,9 +17,9 @@ namespace FeatureTests.On.DependencyInjection
     ")]
     [FeatureScoring(FeatureScoring.NotScored)]
     [SpecialCase(typeof(SimpleInjectorAdapter), @"
-        Simple Injector does not inject properties out of the box, but this behavior can be changed by 
-        replacing the Container.Options.PropertySelectionBehavior. For more info see: 
-        https://simpleinjector.org/noprop.
+        Simple Injector does not inject properties out of the box, but this behavior
+        can be changed by replacing the Container.Options.PropertySelectionBehavior. 
+        For more info see: https://simpleinjector.org/noprop.
     ", Skip = true)]
     public class PropertyTests {
         [Feature]

--- a/DependencyInjection/9_ConvenienceTests.cs
+++ b/DependencyInjection/9_ConvenienceTests.cs
@@ -22,7 +22,7 @@ namespace FeatureTests.On.DependencyInjection {
             most resolvable dependencies.
         ")]
         [SpecialCase(typeof(SimpleInjectorAdapter), @"
-            Simple Injector does not allow resolving types with multiple constructors out of the box, but this
+            Simple Injector does not allow resolving types with multiple constructors out of the box, but this 
             behavior can be changed by replacing the Container.Options.ConstructorResolutionBehavior.
             For more info see: https://simpleinjector.org/xtpcr.
         ", Skip = true)]
@@ -48,8 +48,8 @@ namespace FeatureTests.On.DependencyInjection {
         ")]
         [SpecialCase(typeof(SimpleInjectorAdapter), @"
             Simple Injector does not allow doing any explicit registrations after the first service has been
-            resolved. The rational behind this is described here: https://simpleinjector.org/locked.
-            That resource also describes how to allow registrations to be made at a later point in time.
+            resolved. The rational behind this is described here: https://simpleinjector.org/locked. That resource also
+            describes how to allow registrations to be made at a later point in time.
         ", Skip = true)]
         public void RegistrationAtAnyStage(IContainerAdapter adapter) {
             adapter.RegisterType<IService, IndependentService>();

--- a/DependencyInjection/9_ConvenienceTests.cs
+++ b/DependencyInjection/9_ConvenienceTests.cs
@@ -22,8 +22,8 @@ namespace FeatureTests.On.DependencyInjection {
             most resolvable dependencies.
         ")]
         [SpecialCase(typeof(SimpleInjectorAdapter), @"
-            Simple Injector does not allow resolving types with multiple constructors out of the box, but 
-            this behavior can be changed by replacing the Container.Options.ConstructorResolutionBehavior.
+            Simple Injector does not allow resolving types with multiple constructors out of the box, but this
+            behavior can be changed by replacing the Container.Options.ConstructorResolutionBehavior.
             For more info see: https://simpleinjector.org/xtpcr.
         ", Skip = true)]
         public void ReasonableConstructorSelection(IContainerAdapter adapter) {
@@ -47,9 +47,9 @@ namespace FeatureTests.On.DependencyInjection {
             This can be inconvenient for dynamic situations such as adding plug-ins.
         ")]
         [SpecialCase(typeof(SimpleInjectorAdapter), @"
-            Simple Injector does not allow doing any explicit registrations after the first service has 
-            been resolved. The rational behind this is described here: https://simpleinjector.org/locked.
-            That article also describes how to allow registrations to be made at a later point in time.
+            Simple Injector does not allow doing any explicit registrations after the first service has been
+            resolved. The rational behind this is described here: https://simpleinjector.org/locked.
+            That resource also describes how to allow registrations to be made at a later point in time.
         ", Skip = true)]
         public void RegistrationAtAnyStage(IContainerAdapter adapter) {
             adapter.RegisterType<IService, IndependentService>();

--- a/DependencyInjection/9_ConvenienceTests.cs
+++ b/DependencyInjection/9_ConvenienceTests.cs
@@ -21,11 +21,11 @@ namespace FeatureTests.On.DependencyInjection {
             In this situation, it seems reasonable to select constructor with
             most resolvable dependencies.
         ")]
-        [SpecialCase(typeof(SimpleInjectorAdapter),
-            "Simple Injector does not allow resolving types with multiple constructors out of the box, but " +
-            "this behavior can be changed by replacing the Container.Options.ConstructorResolutionBehavior. " +
-            "For more info see: https://simpleinjector.org/xtpcr.", 
-            Skip = true)]
+        [SpecialCase(typeof(SimpleInjectorAdapter), @"
+            Simple Injector does not allow resolving types with multiple constructors out of the box, but 
+            this behavior can be changed by replacing the Container.Options.ConstructorResolutionBehavior.
+            For more info see: https://simpleinjector.org/xtpcr.
+        ", Skip = true)]
         public void ReasonableConstructorSelection(IContainerAdapter adapter) {
             adapter.RegisterType<IService, IndependentService>();
             adapter.RegisterType<ServiceWithMultipleConstructors>();
@@ -46,11 +46,11 @@ namespace FeatureTests.On.DependencyInjection {
             added before Build.  
             This can be inconvenient for dynamic situations such as adding plug-ins.
         ")]
-        [SpecialCase(typeof(SimpleInjectorAdapter),
-            "Simple Injector does not allow doing any explicit registrations after the first service has " +
-            "been resolved. The rational behind this is described here: https://simpleinjector.org/locked. " + 
-            "That article also describes how to allow registrations to be made at a later point in time.",
-            Skip = true)]
+        [SpecialCase(typeof(SimpleInjectorAdapter), @"
+            Simple Injector does not allow doing any explicit registrations after the first service has 
+            been resolved. The rational behind this is described here: https://simpleinjector.org/locked.
+            That article also describes how to allow registrations to be made at a later point in time.
+        ", Skip = true)]
         public void RegistrationAtAnyStage(IContainerAdapter adapter) {
             adapter.RegisterType<IService, IndependentService>();
             adapter.Resolve<IService>();

--- a/DependencyInjection/9_ConvenienceTests.cs
+++ b/DependencyInjection/9_ConvenienceTests.cs
@@ -21,11 +21,11 @@ namespace FeatureTests.On.DependencyInjection {
             In this situation, it seems reasonable to select constructor with
             most resolvable dependencies.
         ")]
-        [SpecialCase(typeof(SimpleInjectorAdapter), @"
-            Simple Injector does not allow resolving types with multiple constructors out of the box, but this 
-            behavior can be changed by replacing the `Container.Options.ConstructorResolutionBehavior`.
-            For more info see: https://bit.ly/1uqDIYF.
-        ", Skip = true)]
+        [SpecialCase(typeof(SimpleInjectorAdapter),
+            "Simple Injector does not allow resolving types with multiple constructors out of the box, but " +
+            "this behavior can be changed by replacing the Container.Options.ConstructorResolutionBehavior. " +
+            "For more info see: https://simpleinjector.org/xtpcr.", 
+            Skip = true)]
         public void ReasonableConstructorSelection(IContainerAdapter adapter) {
             adapter.RegisterType<IService, IndependentService>();
             adapter.RegisterType<ServiceWithMultipleConstructors>();
@@ -44,13 +44,13 @@ namespace FeatureTests.On.DependencyInjection {
         [Description(@"
             Some containers follow strict Register -> Build -> Resolve flow, new registrations can only be 
             added before Build.  
-            This can be inconvenient for dynamic situations such as adding plugins.
+            This can be inconvenient for dynamic situations such as adding plug-ins.
         ")]
-        [SpecialCase(typeof(SimpleInjectorAdapter), @"
-            Simple Injector does allow doing any explicit registrations after the first service has been
-            resolved. The rational behind this is described here: https://bit.ly/1yfdRqd. That article also
-            describes how to allow registrations to be made at a later point in time.
-        ", Skip = true)]
+        [SpecialCase(typeof(SimpleInjectorAdapter),
+            "Simple Injector does not allow doing any explicit registrations after the first service has " +
+            "been resolved. The rational behind this is described here: https://simpleinjector.org/locked. " + 
+            "That article also describes how to allow registrations to be made at a later point in time.",
+            Skip = true)]
         public void RegistrationAtAnyStage(IContainerAdapter adapter) {
             adapter.RegisterType<IService, IndependentService>();
             adapter.Resolve<IService>();

--- a/DependencyInjection/DependencyInjection.csproj
+++ b/DependencyInjection/DependencyInjection.csproj
@@ -162,17 +162,17 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\#packages\ReflectionMagic.2.0.3\lib\net40\ReflectionMagic.dll</HintPath>
     </Reference>
-    <Reference Include="SimpleInjector, Version=2.7.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\#packages\SimpleInjector.2.7.0\lib\net45\SimpleInjector.dll</HintPath>
+    <Reference Include="SimpleInjector, Version=2.7.3.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\#packages\SimpleInjector.2.7.3\lib\net45\SimpleInjector.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="SimpleInjector.Diagnostics, Version=2.7.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\#packages\SimpleInjector.2.7.0\lib\net45\SimpleInjector.Diagnostics.dll</HintPath>
+    <Reference Include="SimpleInjector.Diagnostics, Version=2.7.3.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\#packages\SimpleInjector.2.7.3\lib\net45\SimpleInjector.Diagnostics.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="SimpleInjector.Integration.Web, Version=2.7.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\#packages\SimpleInjector.Integration.Web.2.7.0\lib\net40\SimpleInjector.Integration.Web.dll</HintPath>
+    <Reference Include="SimpleInjector.Integration.Web, Version=2.7.3.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\#packages\SimpleInjector.Integration.Web.2.7.3\lib\net40\SimpleInjector.Integration.Web.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Speedioc">
       <HintPath>..\#packages\Speedioc.0.1.33\lib\net40\Speedioc.dll</HintPath>

--- a/DependencyInjection/packages.config
+++ b/DependencyInjection/packages.config
@@ -30,8 +30,8 @@
   <package id="Ninject.Web.Common" version="3.2.3.0" targetFramework="net45" />
   <package id="Nuget.Core" version="2.8.3" targetFramework="net45" />
   <package id="ReflectionMagic" version="2.0.3" targetFramework="net45" />
-  <package id="SimpleInjector" version="2.7.0" targetFramework="net45" />
-  <package id="SimpleInjector.Integration.Web" version="2.7.0" targetFramework="net45" />
+  <package id="SimpleInjector" version="2.7.3" targetFramework="net45" />
+  <package id="SimpleInjector.Integration.Web" version="2.7.3" targetFramework="net45" />
   <package id="Speedioc" version="0.1.33" targetFramework="net45" />
   <package id="Spring.Core" version="1.3.2" targetFramework="net45" />
   <package id="structuremap" version="3.1.4.143" targetFramework="net45" />


### PR DESCRIPTION
Updated the special case messages for Simple Injector:
 - Replaced the ugly bit.ly links with links to simpleinjector.org.
 - Replaced the multi-line text with concatenated text. This makes the text format correctly in a title popup in html.

Upgraded to Simple Injector 2.7.3.