### PR TITLE
changed: Updated DryIoc to 2.0.0

### DIFF
--- a/DependencyInjection/Adapters/DryIocAdapter.cs
+++ b/DependencyInjection/Adapters/DryIocAdapter.cs
@@ -7,11 +7,12 @@ using FeatureTests.On.DependencyInjection.Adapters.Interface;
 namespace FeatureTests.On.DependencyInjection.Adapters
 {
     public class DryIocAdapter : ContainerAdapterBase {
-        private readonly Container container = new Container(
-            rules => rules.With(Constructor.WithAllResolvableArguments, propertiesAndFields: PropertiesAndFields.PublicNonPrimitive)
+        private readonly Container container = new Container(rules => rules.With(
+            FactoryMethod.ConstructorWithResolvableArguments, 
+            propertiesAndFields: PropertiesAndFields.Auto)
         );
 
-        private Container webRequestScoped;
+        private IContainer webRequestScoped;
 
         public override Assembly Assembly {
             get { return typeof(Container).Assembly; }
@@ -38,7 +39,7 @@ namespace FeatureTests.On.DependencyInjection.Adapters
         }
 
         public override void AfterBeginWebRequest() {
-            this.webRequestScoped = container.BeginScope();
+            this.webRequestScoped = container.OpenScope();
         }
 
         public override void BeforeEndWebRequest() {

--- a/DependencyInjection/DependencyInjection.csproj
+++ b/DependencyInjection/DependencyInjection.csproj
@@ -71,9 +71,9 @@
     <Reference Include="Common.Logging.Core">
       <HintPath>..\#packages\Common.Logging.Core.3.1.0\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
-    <Reference Include="DryIoc, Version=2.0.0.123, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\#packages\DryIoc.dll.2.0.0-preview123\lib\net45\DryIoc.dll</HintPath>
+    <Reference Include="DryIoc">
+      <HintPath>..\#packages\DryIoc.dll.2.0.0\lib\net45\DryIoc.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Dynamo.Ioc">
       <HintPath>..\#packages\Dynamo.Ioc.3.0.2.0\lib\net45\Dynamo.Ioc.dll</HintPath>

--- a/DependencyInjection/packages.config
+++ b/DependencyInjection/packages.config
@@ -9,7 +9,7 @@
   <package id="Common.Logging" version="3.1.0" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.1.0" targetFramework="net45" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
-  <package id="DryIoc.dll" version="2.0.0-preview123" targetFramework="net45" />
+  <package id="DryIoc.dll" version="2.0.0" targetFramework="net45" />
   <package id="Dynamo.Ioc" version="3.0.2.0" targetFramework="net45" />
   <package id="Dynamo.Ioc.Extensions" version="3.0.1.1" targetFramework="net45" />
   <package id="Endjin.Core.Composition" version="2.2.0.45" targetFramework="net45" />


### PR DESCRIPTION
Hello,

I have update to DryIoc 2.0.0 release.
The build is fine. But running the Runner project fails with error from attachment. Something with this IP:

> No connection could be made because the target machine actively refused it 217.70.184.38:80

Could you look into it?

[net-feature-tests-error.txt](https://github.com/ashmind/net-feature-tests/files/41375/net-feature-tests-error.txt)